### PR TITLE
AllgatherFlattened fix (result size)

### DIFF
--- a/MPI/Intracommunicator.cs
+++ b/MPI/Intracommunicator.cs
@@ -243,7 +243,7 @@ namespace MPI
             }
             else
             {
-                int size = 0;
+                int size = counts[0];
                 int[] displs = new int[counts.Length];
                 displs[0] = 0;
                 for (int i = 1; i < counts.Length; i++)


### PR DESCRIPTION
A clear algorythmic bug revealing while the rank 0 process needs to send any data within AllgatherFlattened. Inside the loop at line 249, summed variable `size` misses `counts[0]`  term.
The internal test in Tests\AllgatherTest has been succeeding since the rank 0 process does not ask to send any data (`counts[0]==0`) within the test.